### PR TITLE
Implement whitelisting emails by regex. #7

### DIFF
--- a/saferecipient/__init__.py
+++ b/saferecipient/__init__.py
@@ -1,8 +1,8 @@
 """SMTP email backend class that only sends email to a safe email address"""
 import re
+from django.conf import settings
 from django.core.mail.backends.smtp import EmailBackend as SMTPEmailBackend
 from email.mime.text import MIMEText
-from django.conf import settings
 
 
 class EmailBackend(SMTPEmailBackend):
@@ -13,6 +13,7 @@ class EmailBackend(SMTPEmailBackend):
     The original to and from are added to a text file
     that is attached to the message.
     """
+
     def send_messages(self, email_messages):
         for message in email_messages:
             self._safeguard(message)
@@ -38,7 +39,8 @@ class EmailBackend(SMTPEmailBackend):
         message.attach(text_attachment)
 
     def _only_safe_emails(self, emails):
-        """"Given a list of emails, checks whether they are all in the white list."""
+        """"Given a list of emails, checks whether they are all in the white
+        list."""
 
         if any(not self._is_whitelisted(to) for to in emails):
             emails = [email for email in emails if self._is_whitelisted(email)]
@@ -47,7 +49,8 @@ class EmailBackend(SMTPEmailBackend):
         return emails
 
     def _is_whitelisted(self, email):
-        """"Check if an email is in the whitelist. If there's no whitelist, it's assumed it's not whitelisted. """
+        """Check if an email is in the whitelist. If there's no whitelist,
+        it's assumed it's not whitelisted."""
 
         return hasattr(settings, "SAFE_EMAIL_WHITELIST") and \
-               any(re.match(m, email) for m in settings.SAFE_EMAIL_WHITELIST)
+            any(re.match(m, email) for m in settings.SAFE_EMAIL_WHITELIST)

--- a/saferecipient/tests.py
+++ b/saferecipient/tests.py
@@ -1,28 +1,77 @@
-from django.test import TestCase
 from django.core.mail import EmailMultiAlternatives
+from django.test import TestCase
+
 from saferecipient import EmailBackend
 
 
 class TestEmailBackend(TestCase):
+    SAFE_EMAIL = 'safe@example.com'
+
     def test_safeguard(self):
-        with self.settings(SAFE_EMAIL_RECIPIENT='safe@example.com'):
+        with self.settings(SAFE_EMAIL_RECIPIENT=self.SAFE_EMAIL):
             message = self._setup_message()
             EmailBackend()._safeguard(message)
             self.assertEquals(message.from_email, 'safe@example.com')
             self.assertEquals(message.to, ['safe@example.com'])
-            self.assertEquals(message.cc, [])
+            self.assertEquals(message.cc, ['safe@example.com'])
             self.assertEquals(
                 message.attachments[0].get_payload(),
                 ("Original From: sender@example.com\nOriginal To: "
                  "['recipient@example.com']\nOriginal CC: "
                  "['cc_recipient@example.com']\nOriginal BCC: []\n"))
 
+    def test_safeguard_with_whitelist(self):
+        with self.settings(SAFE_EMAIL_RECIPIENT=self.SAFE_EMAIL), \
+             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+            message = self._setup_message(from_email='sender@example.com',
+                                          to=['recipient@example.com'],
+                                          cc=["safe+safe@example.org"],
+                                          bcc=["unsafe@example.net"])
+            EmailBackend()._safeguard(message)
+            self.assertEquals(message.from_email, 'sender@example.com')
+            self.assertEquals(message.to, ['recipient@example.com'])
+            self.assertEquals(message.cc, ["safe+safe@example.org"])
+            self.assertEquals(message.attachments[0].get_payload(),
+                              ("Original From: sender@example.com\n"
+                               "Original To: ['recipient@example.com']\n"
+                               "Original CC: ['safe+safe@example.org']\n"
+                               "Original BCC: ['unsafe@example.net']\n"))
+
     def test_no_setting(self):
         message = self._setup_message()
         self.assertRaises(
             AttributeError, EmailBackend()._safeguard, message)
 
-    def _setup_message(self):
-        return EmailMultiAlternatives(
-            subject='test', body='TEST', from_email='sender@example.com',
-            to=['recipient@example.com'], cc=['cc_recipient@example.com'])
+    def test_only_safe_emails(self):
+        with self.settings(SAFE_EMAIL_RECIPIENT=self.SAFE_EMAIL), \
+             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+            eb = EmailBackend()
+            self.assertEqual([], eb._only_safe_emails([]))
+            self.assertEqual([self.SAFE_EMAIL], eb._only_safe_emails(["unsafe@example.org"]))
+            self.assertEqual([self.SAFE_EMAIL], eb._only_safe_emails(["unsafe@example.org", "unsafe2@example.org"]))
+            self.assertEqual([self.SAFE_EMAIL],
+                             eb._only_safe_emails([self.SAFE_EMAIL, "unsafe@example.org", "unsafe2@example.org"]))
+            self.assertEqual(["safe+2@example.com", self.SAFE_EMAIL],
+                             eb._only_safe_emails(["safe+2@example.com", self.SAFE_EMAIL, "unsafe@example.org",
+                                                   "unsafe2@example.org"]))
+            self.assertEqual(["safe+2@example.com", self.SAFE_EMAIL, "safe@example.org"],
+                             eb._only_safe_emails(["safe+2@example.com", self.SAFE_EMAIL, "unsafe@example.org",
+                                                   "unsafe2@example.org", "safe@example.org"]))
+
+    def test_whitelist(self):
+        with self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+            eb = EmailBackend()
+            self.assertTrue(eb._is_whitelisted("example@example.com"))
+            self.assertTrue(eb._is_whitelisted("example2@example.com"))
+            self.assertTrue(eb._is_whitelisted("safe@example.org"))
+            self.assertTrue(eb._is_whitelisted("safe+2@example.org"))
+            self.assertFalse(eb._is_whitelisted("unsafe@example.org"))
+
+    def _setup_message(self, from_email='sender@example.com', to=None, cc=None, bcc=None):
+        if to is None:
+            to = ['recipient@example.com']
+        if cc is None:
+            cc = ['cc_recipient@example.com']
+        if bcc is None:
+            bcc = []
+        return EmailMultiAlternatives(from_email=from_email, to=to, cc=cc, bcc=bcc, subject='test', body='TEST')

--- a/saferecipient/tests.py
+++ b/saferecipient/tests.py
@@ -22,7 +22,8 @@ class TestEmailBackend(TestCase):
 
     def test_safeguard_with_whitelist(self):
         with self.settings(SAFE_EMAIL_RECIPIENT=self.SAFE_EMAIL), \
-             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com",
+                                                 r"safe.*@example\.org"]):
             message = self._setup_message(from_email='sender@example.com',
                                           to=['recipient@example.com'],
                                           cc=["safe+safe@example.org"],
@@ -44,22 +45,36 @@ class TestEmailBackend(TestCase):
 
     def test_only_safe_emails(self):
         with self.settings(SAFE_EMAIL_RECIPIENT=self.SAFE_EMAIL), \
-             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+             self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com",
+                                                 r"safe.*@example\.org"]):
             eb = EmailBackend()
             self.assertEqual([], eb._only_safe_emails([]))
-            self.assertEqual([self.SAFE_EMAIL], eb._only_safe_emails(["unsafe@example.org"]))
-            self.assertEqual([self.SAFE_EMAIL], eb._only_safe_emails(["unsafe@example.org", "unsafe2@example.org"]))
             self.assertEqual([self.SAFE_EMAIL],
-                             eb._only_safe_emails([self.SAFE_EMAIL, "unsafe@example.org", "unsafe2@example.org"]))
-            self.assertEqual(["safe+2@example.com", self.SAFE_EMAIL],
-                             eb._only_safe_emails(["safe+2@example.com", self.SAFE_EMAIL, "unsafe@example.org",
+                             eb._only_safe_emails(["unsafe@example.org"]))
+            self.assertEqual([self.SAFE_EMAIL],
+                             eb._only_safe_emails(["unsafe@example.org",
                                                    "unsafe2@example.org"]))
-            self.assertEqual(["safe+2@example.com", self.SAFE_EMAIL, "safe@example.org"],
-                             eb._only_safe_emails(["safe+2@example.com", self.SAFE_EMAIL, "unsafe@example.org",
-                                                   "unsafe2@example.org", "safe@example.org"]))
+            self.assertEqual([self.SAFE_EMAIL],
+                             eb._only_safe_emails([self.SAFE_EMAIL,
+                                                   "unsafe@example.org",
+                                                   "unsafe2@example.org"]))
+            self.assertEqual(["safe+2@example.com", self.SAFE_EMAIL],
+                             eb._only_safe_emails(["safe+2@example.com",
+                                                   self.SAFE_EMAIL,
+                                                   "unsafe@example.org",
+                                                   "unsafe2@example.org"]))
+            self.assertEqual(["safe+2@example.com",
+                              self.SAFE_EMAIL,
+                              "safe@example.org"],
+                             eb._only_safe_emails(["safe+2@example.com",
+                                                   self.SAFE_EMAIL,
+                                                   "unsafe@example.org",
+                                                   "unsafe2@example.org",
+                                                   "safe@example.org"]))
 
     def test_whitelist(self):
-        with self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com", r"safe.*@example\.org"]):
+        with self.settings(SAFE_EMAIL_WHITELIST=[r".*@example\.com",
+                                                 r"safe.*@example\.org"]):
             eb = EmailBackend()
             self.assertTrue(eb._is_whitelisted("example@example.com"))
             self.assertTrue(eb._is_whitelisted("example2@example.com"))
@@ -67,11 +82,13 @@ class TestEmailBackend(TestCase):
             self.assertTrue(eb._is_whitelisted("safe+2@example.org"))
             self.assertFalse(eb._is_whitelisted("unsafe@example.org"))
 
-    def _setup_message(self, from_email='sender@example.com', to=None, cc=None, bcc=None):
+    def _setup_message(self, from_email='sender@example.com', to=None,
+                       cc=None, bcc=None):
         if to is None:
             to = ['recipient@example.com']
         if cc is None:
             cc = ['cc_recipient@example.com']
         if bcc is None:
             bcc = []
-        return EmailMultiAlternatives(from_email=from_email, to=to, cc=cc, bcc=bcc, subject='test', body='TEST')
+        return EmailMultiAlternatives(from_email=from_email, to=to, cc=cc,
+                                      bcc=bcc, subject='test', body='TEST')


### PR DESCRIPTION
There's a small change in semantics, which is that a safe email can end up both in to and cc, as it tries to retain to, cc, and bcc as original as possible if the emails match the whitelist.